### PR TITLE
Set $final variable to avoid parsing errors

### DIFF
--- a/IXR_Library.php
+++ b/IXR_Library.php
@@ -211,6 +211,7 @@ class IXR_Message
         xml_set_character_data_handler($this->_parser, 'cdata');
         $chunk_size = 262144; // 256Kb, parse in chunks to avoid the RAM usage on very large messages
         do {
+            $final = false;
             if (strlen($this->message) <= $chunk_size) {
                 $final = true;
             }


### PR DESCRIPTION
This has been addressed elsewhere: https://core.trac.wordpress.org/attachment/ticket/15703/15703.diff
